### PR TITLE
remove warning

### DIFF
--- a/src/hamcrest/lib.rs
+++ b/src/hamcrest/lib.rs
@@ -1,4 +1,4 @@
-#![crate_id = "hamcrest"]
+#![crate_name = "hamcrest"]
 #![crate_type = "lib"]
 
 extern crate collections;


### PR DESCRIPTION
Remove warning about the deprecated #[crate_id] attribute
