### PR TITLE
Fix 'cargo test'

### DIFF
--- a/src/hamcrest/matchers/equal_to.rs
+++ b/src/hamcrest/matchers/equal_to.rs
@@ -33,11 +33,11 @@ mod test {
   #[test]
   fn test_equality_of_ints() {
     // Successful match
-    assert_that(&1, is(equal_to(&1)));
+    assert_that(&1, is(equal_to(&1i)));
 
     // Unsuccessful match
     let res = task::try(proc() {
-      assert_that(&2, is(equal_to(&1)));
+      assert_that(&2, is(equal_to(&1i)));
     });
 
     assert!(res.is_err());

--- a/src/hamcrest/matchers/existing_path.rs
+++ b/src/hamcrest/matchers/existing_path.rs
@@ -52,7 +52,7 @@ mod test {
 
   #[test]
   fn test_with_existing_file() {
-    let path = path(os::getenv("TEST_EXISTS_FILE"));
+    let path = path(os::getenv("TEST_EXISTS_FILE"), "./README.md");
 
     assert_that(&path, is(existing_path()));
     assert_that(&path, is(existing_file()));
@@ -61,7 +61,7 @@ mod test {
 
   #[test]
   fn test_with_existing_dir() {
-    let path = path(os::getenv("TEST_EXISTS_DIR"));
+    let path = path(os::getenv("TEST_EXISTS_DIR"), "./target");
 
     assert_that(&path, is(existing_path()));
     assert_that(&path, is(existing_dir()));
@@ -70,14 +70,14 @@ mod test {
 
   #[test]
   fn test_with_nonexisting_path() {
-    let path = path(os::getenv("TEST_EXISTS_NONE"));
+    let path = path(os::getenv("TEST_EXISTS_NONE"), "./zomg.txt");
 
     assert_that(&path, is_not(existing_path()));
     assert_that(&path, is_not(existing_file()));
     assert_that(&path, is_not(existing_dir()));
   }
 
-  fn path(path: Option<String>) -> Path {
-    Path::new(path.unwrap())
+  fn path(path: Option<String>, default: &str) -> Path {
+    Path::new(path.unwrap_or(default.to_string()))
   }
 }

--- a/src/hamcrest/matchers/vecs.rs
+++ b/src/hamcrest/matchers/vecs.rs
@@ -88,13 +88,13 @@ mod test {
 
     #[test]
     fn test_vec_contains() {
-        assert_that(&vec!(1, 2, 3), contains(vec!(1, 2)));
-        assert_that(&vec!(1, 2, 3), not(contains(vec!(4))));
+        assert_that(&vec!(1i, 2, 3), contains(vec!(1i, 2)));
+        assert_that(&vec!(1i, 2, 3), not(contains(vec!(4i))));
     }
 
     #[test]
     fn test_vec_contains_exactly() {
-        assert_that(&vec!(1, 2, 3), contains(vec!(1, 2, 3)).exactly());
-        assert_that(&vec!(1, 2, 3), not(contains(vec!(1, 2)).exactly()));
+        assert_that(&vec!(1i, 2, 3), contains(vec!(1i, 2, 3)).exactly());
+        assert_that(&vec!(1i, 2, 3), not(contains(vec!(1i, 2)).exactly()));
     }
 }


### PR DESCRIPTION
I'm not sure what that environment variable stuff was doing in there, so I left it in, but added a hard-coded fallback.

Also fixed some default integer suffixes.
