### PR TITLE
Use `Debug` not `Display` for printing custom objects.

### DIFF
--- a/src/hamcrest/matchers/close_to.rs
+++ b/src/hamcrest/matchers/close_to.rs
@@ -7,13 +7,13 @@ pub struct CloseTo<T> {
   epsilon: T
 }
 
-impl<T: fmt::Display> fmt::Display for CloseTo<T> {
+impl<T: fmt::Debug> fmt::Display for CloseTo<T> {
   fn fmt(&self, f: &mut Formatter) -> fmt::Result {
       self.expected.fmt(f)
   }
 }
 
-impl<T : Float + PartialEq + fmt::Display> Matcher<T> for CloseTo<T> {
+impl<T : Float + PartialEq + fmt::Debug> Matcher<T> for CloseTo<T> {
   fn matches(&self, actual: T) -> MatchResult {
     let d = (self.expected - actual).abs();
 
@@ -26,16 +26,16 @@ impl<T : Float + PartialEq + fmt::Display> Matcher<T> for CloseTo<T> {
       success()
     }
     else {
-      Err(format!("was {}", actual))
+      Err(format!("was {:?}", actual))
     }
   }
 }
 
-pub fn close_to<T: Float + PartialEq + NumCast + fmt::Display>(expected: T) -> CloseTo<T> {
+pub fn close_to<T: Float + PartialEq + NumCast + fmt::Debug>(expected: T) -> CloseTo<T> {
     close_to_eps(expected, cast::<f32, T>(0.00001).unwrap())
 }
 
-pub fn close_to_eps<T: Float + PartialEq + fmt::Display>(expected: T, epsilon: T) -> CloseTo<T> {
+pub fn close_to_eps<T: Float + PartialEq + fmt::Debug>(expected: T, epsilon: T) -> CloseTo<T> {
   CloseTo { expected: expected, epsilon: epsilon }
 }
 

--- a/src/hamcrest/matchers/none.rs
+++ b/src/hamcrest/matchers/none.rs
@@ -13,10 +13,10 @@ impl<T> fmt::Display for IsNone<T> {
   }
 }
 
-impl<T: fmt::Display> Matcher<Option<T>> for IsNone<T> {
+impl<T: fmt::Debug> Matcher<Option<T>> for IsNone<T> {
   fn matches(&self, actual: Option<T>) -> MatchResult {
     match actual {
-        Some(s) => Err(format!("was Some({})", s)),
+        Some(s) => Err(format!("was Some({:?})", s)),
         None => success(),
     }
   }

--- a/src/hamcrest/matchers/vecs.rs
+++ b/src/hamcrest/matchers/vecs.rs
@@ -41,7 +41,7 @@ impl<T> Contains<T> {
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Contains<T> {
+impl<T: fmt::Debug> fmt::Display for Contains<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.exactly {
             write!(f, "containing exactly {}", Pretty(&self.items))
@@ -51,7 +51,7 @@ impl<T: fmt::Display> fmt::Display for Contains<T> {
     }
 }
 
-impl<'a, T: fmt::Display + PartialEq + Clone> Matcher<&'a Vec<T>> for Contains<T> {
+impl<'a, T: fmt::Debug + PartialEq + Clone> Matcher<&'a Vec<T>> for Contains<T> {
   fn matches(&self, actual: &Vec<T>) -> MatchResult {
     let mut rem = actual.clone();
 
@@ -76,12 +76,12 @@ pub fn contains<T>(items: Vec<T>) -> Contains<T> {
 
 struct Pretty<'a, T: 'a>(&'a [T]);
 
-impl<'a, T: fmt::Display> fmt::Display for Pretty<'a, T> {
+impl<'a, T: fmt::Debug> fmt::Display for Pretty<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "["));
         for (i, t) in self.0.iter().enumerate() {
             if i != 0 { try!(write!(f, ", ")); }
-            try!(write!(f, "{}", t));
+            try!(write!(f, "{:?}", t));
         }
         write!(f, "]")
     }


### PR DESCRIPTION
The `Debug` trait was used by the `equal_to` matcher, but the `close_to`, `Optional` and `Vec` matchers used `Display` for printing custom objects.