### PR TITLE
Refactor `CloseTo` matcher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,8 @@
 name = "hamcrest"
 version = "0.1.0"
 authors = ["Carllerche <me@carllerche.com>"]
+
+[dependencies]
+
+num = "*"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ name = "hamcrest"
 version = "0.1.0"
 authors = ["Carllerche <me@carllerche.com>"]
 
-[dependencies]
+[dependencies.num]
 
-num = "*"
-
+git = "https://github.com/rust-lang/num"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ let res = task::try(proc() {
 assert!(res.is_err());
 ```
 
+### close\_to
+
+```{rust}
+assert_that(1e-40f32, is(close_to(0.0, 0.01)));
+assert_that(1e-40f32, is_not(close_to(0.0, 0.000001)));
+```
+
 ### existing\_{file,path,dir}
 
 ```{rust}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A port of [Hamcrest](http://hamcrest.org/) to [Rust](http://rust-lang.org).
 To use Hamcrest, add this to your `Cargo.toml`:
 
 ```
-[dependencies.hamcrest]
+[dev-dependencies.hamcrest]
 
 git = "https://github.com/carllerche/hamcrest-rust.git"
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![crate_name = "hamcrest"]
 #![crate_type = "lib"]
 
+extern crate num;
+
 pub use core::{assert_that, expect, success, Matcher, MatchResult};
 pub use matchers::is::{is, is_not};
 pub use matchers::is::is_not as not;

--- a/src/matchers/close_to.rs
+++ b/src/matchers/close_to.rs
@@ -19,25 +19,7 @@ impl<T: Debug> Display for CloseTo<T> {
     }
 }
 
-/// This is just a fix until rust-lang/num#93 is fixed.
-pub trait FloatMinPositive {
-    /// Returns the smallest positive, normalized value that this type can represent.
-    fn min_positive_value() -> Self;
-}
-
-impl FloatMinPositive for f32 {
-    fn min_positive_value() -> Self {
-        f32::MIN_POSITIVE
-    }
-}
-
-impl FloatMinPositive for f64 {
-    fn min_positive_value() -> Self {
-        f64::MIN_POSITIVE
-    }
-}
-
-impl<T: Float + Zero + FloatMinPositive + Debug> Matcher<T> for CloseTo<T> {
+impl<T: Float + Zero + Debug> Matcher<T> for CloseTo<T> {
     fn matches(&self, actual: T) -> MatchResult {
         let a = self.expected.abs();
         let b = actual.abs();
@@ -49,8 +31,8 @@ impl<T: Float + Zero + FloatMinPositive + Debug> Matcher<T> for CloseTo<T> {
             a == b
             // a or b is zero or both are extremely close to it
             // relative error is less meaningful here
-            || ((a == Zero::zero() || b == Zero::zero() || d < FloatMinPositive::min_positive_value()) &&
-                d < (self.epsilon * FloatMinPositive::min_positive_value()))
+            || ((a == Zero::zero() || b == Zero::zero() || d < Float::min_positive_value()) &&
+                d < (self.epsilon * Float::min_positive_value()))
             // use relative error
             || d / (a + b).min(Float::max_value()) < self.epsilon;
 

--- a/src/matchers/close_to.rs
+++ b/src/matchers/close_to.rs
@@ -1,3 +1,5 @@
+use num::{Float};
+use num::traits::cast;
 use std::fmt::{self, Formatter};
 use {success, Matcher, MatchResult};
 
@@ -12,8 +14,8 @@ impl<T: fmt::Debug> fmt::Display for CloseTo<T> {
     }
 }
 
-impl Matcher<f64> for CloseTo<f64> {
-    fn matches(&self, actual: f64) -> MatchResult {
+impl<T: Float + fmt::Debug> Matcher<T> for CloseTo<T> {
+    fn matches(&self, actual: T) -> MatchResult {
         // Handle cases like infinity / nan
         if self.expected == actual {
             return success();
@@ -21,7 +23,7 @@ impl Matcher<f64> for CloseTo<f64> {
 
         let delta = (self.expected - actual).abs() - self.delta;
 
-        if delta <= 0.0 {
+        if delta <= cast(0.0).unwrap() {
             return success();
         }
 
@@ -49,6 +51,8 @@ mod test {
         assert_that(f64::INFINITY, is(close_to(f64::INFINITY, 0.00001)));
         assert_that(1e-40f64, is(close_to(0.0, 0.01)));
         assert_that(1e-40f64, is(close_to(0.0, 0.000001)));
+        assert_that(1e-40f32, is(close_to(0.0, 0.01)));
+        assert_that(1e-40f32, is(close_to(0.0, 0.000001)));
 
         // Unsuccessful match
         assert!(thread::spawn(|| {

--- a/src/matchers/close_to.rs
+++ b/src/matchers/close_to.rs
@@ -1,66 +1,86 @@
-use num::{Float};
-use num::traits::cast;
-use std::fmt::{self, Formatter};
+use num::{Float, Zero};
+use std::fmt::{self, Display, Debug, Formatter};
+use std::{f32, f64};
 use {success, Matcher, MatchResult};
 
+/// Compares two floating point values for equality.
+///
+/// The comparison is based on a relative error metric and uses special
+/// fallbacks for certain edge cases like very small numbers. The exact
+/// algorithm is described [here](http://floating-point-gui.de/errors/comparison/).
 pub struct CloseTo<T> {
     expected: T,
-    delta: T,
+    epsilon: T,
 }
 
-impl<T: fmt::Debug> fmt::Display for CloseTo<T> {
+impl<T: Debug> Display for CloseTo<T> {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         self.expected.fmt(f)
     }
 }
 
-impl<T: Float + fmt::Debug> Matcher<T> for CloseTo<T> {
-    fn matches(&self, actual: T) -> MatchResult {
-        // Handle cases like infinity / nan
-        if self.expected == actual {
-            return success();
-        }
+/// This is just a fix until rust-lang/num#93 is fixed.
+pub trait FloatMinPositive {
+    /// Returns the smallest positive, normalized value that this type can represent.
+    fn min_positive_value() -> Self;
+}
 
-        let delta = (self.expected - actual).abs() - self.delta;
-
-        if delta <= cast(0.0).unwrap() {
-            return success();
-        }
-
-        Err(format!("was {:?}", actual))
+impl FloatMinPositive for f32 {
+    fn min_positive_value() -> Self {
+        f32::MIN_POSITIVE
     }
 }
 
-pub fn close_to<T>(expected: T, delta: T) -> CloseTo<T> {
+impl FloatMinPositive for f64 {
+    fn min_positive_value() -> Self {
+        f64::MIN_POSITIVE
+    }
+}
+
+impl<T: Float + Zero + FloatMinPositive + Debug> Matcher<T> for CloseTo<T> {
+    fn matches(&self, actual: T) -> MatchResult {
+        let a = self.expected.abs();
+        let b = actual.abs();
+
+        let d = (a - b).abs();
+
+        let close =
+            // shortcut, handles infinities
+            a == b
+            // a or b is zero or both are extremely close to it
+            // relative error is less meaningful here
+            || ((a == Zero::zero() || b == Zero::zero() || d < FloatMinPositive::min_positive_value()) &&
+                d < (self.epsilon * FloatMinPositive::min_positive_value()))
+            // use relative error
+            || d / (a + b).min(Float::max_value()) < self.epsilon;
+
+        if close {
+            success()
+        } else {
+            Err(format!("was {:?}", actual))
+        }
+    }
+}
+
+pub fn close_to<T>(expected: T, epsilon: T) -> CloseTo<T> {
     CloseTo {
         expected: expected,
-        delta: delta
+        epsilon: epsilon
     }
 }
 
 #[cfg(test)]
 mod test {
     use std::f64;
-    use std::thread;
-    use {assert_that,is,close_to};
+    use {assert_that,is,not,close_to};
 
     #[test]
     fn test_equality_of_floats() {
-        // Successful match
         assert_that(1.0f64, is(close_to(1.0, 0.00001)));
         assert_that(f64::INFINITY, is(close_to(f64::INFINITY, 0.00001)));
-        assert_that(1e-40f64, is(close_to(0.0, 0.01)));
-        assert_that(1e-40f64, is(close_to(0.0, 0.000001)));
         assert_that(1e-40f32, is(close_to(0.0, 0.01)));
-        assert_that(1e-40f32, is(close_to(0.0, 0.000001)));
-
-        // Unsuccessful match
-        assert!(thread::spawn(|| {
-            assert_that(2.0, is(close_to(1.0f64, 0.0001)));
-        }).join().is_err());
-
-        assert!(thread::spawn(move || {
-            assert_that(f64::NAN, is(close_to(f64::NAN, 0.0001)));
-        }).join().is_err());
+        assert_that(1e-40f32, is(not(close_to(0.0, 0.000001))));
+        assert_that(2.0, is(not(close_to(1.0f64, 0.00001))));
+        assert_that(f64::NAN, is(not(close_to(f64::NAN, 0.00001))));
     }
 }


### PR DESCRIPTION
Use the comparison algorithm described [here](http://floating-point-gui.de/errors/comparison/) to perform the actual comparison involving a certain `epsilon`.
The trait `FloatMinPositive` might be removed once rust-lang/num#93 is resolved.