### PR TITLE
Split up tests & find better names

### DIFF
--- a/src/matchers/close_to.rs
+++ b/src/matchers/close_to.rs
@@ -66,12 +66,20 @@ mod test {
     use {assert_that,is,not,close_to};
 
     #[test]
-    fn test_equality_of_floats() {
+    fn equality_of_floats() {
         assert_that(1.0f64, is(close_to(1.0, 0.00001)));
-        assert_that(f64::INFINITY, is(close_to(f64::INFINITY, 0.00001)));
         assert_that(1e-40f32, is(close_to(0.0, 0.01)));
         assert_that(1e-40f32, is(not(close_to(0.0, 0.000001))));
         assert_that(2.0, is(not(close_to(1.0f64, 0.00001))));
+    }
+
+    #[test]
+    fn it_can_handle_infinity() {
+        assert_that(f64::INFINITY, is(close_to(f64::INFINITY, 0.00001)));
+    }
+
+    #[test]
+    fn it_can_handle_nan() {
         assert_that(f64::NAN, is(not(close_to(f64::NAN, 0.00001))));
     }
 }

--- a/src/matchers/equal_to.rs
+++ b/src/matchers/equal_to.rs
@@ -38,19 +38,16 @@ pub fn equal_to<T : PartialEq + fmt::Debug>(expected: T) -> EqualTo<T> {
 
 #[cfg(test)]
 mod test {
-    use std::thread;
     use {assert_that,is,equal_to};
 
     #[test]
-    fn test_equality_of_ints() {
-        // Successful match
+    fn equality_of_ints() {
         assert_that(&1, is(equal_to(&1)));
+    }
 
-        // Unsuccessful match
-        let res = thread::spawn(|| {
-            assert_that(&2, is(equal_to(&1)));
-        }).join();
-
-        assert!(res.is_err());
+    #[test]
+    #[should_panic]
+    fn unsuccessful_match() {
+        assert_that(&2, is(equal_to(&1)));
     }
 }

--- a/src/matchers/existing_path.rs
+++ b/src/matchers/existing_path.rs
@@ -85,7 +85,7 @@ mod test {
     use {assert_that, is, is_not, existing_file, existing_dir, existing_path};
 
     #[test]
-    fn test_with_existing_file() {
+    fn an_existing_file() {
         let path = path(env::var("TEST_EXISTS_FILE"), "./README.md");
 
         assert_that(&path, is(existing_path()));
@@ -94,7 +94,7 @@ mod test {
     }
 
     #[test]
-    fn test_with_existing_dir() {
+    fn an_existing_dir() {
         let path = path(env::var("TEST_EXISTS_DIR"), "./target");
 
         assert_that(&path, is(existing_path()));
@@ -103,7 +103,7 @@ mod test {
     }
 
     #[test]
-    fn test_with_nonexisting_path() {
+    fn a_nonexisting_path() {
         let path = path(env::var("TEST_EXISTS_NONE"), "./zomg.txt");
 
         assert_that(&path, is_not(existing_path()));

--- a/src/matchers/none.rs
+++ b/src/matchers/none.rs
@@ -41,8 +41,12 @@ mod test {
     use {assert_that,is,is_not,none};
 
     #[test]
-    fn test_none_is_none() {
+    fn none_is_none() {
         assert_that(None, is(none::<i8>()));
+    }
+
+    #[test]
+    fn some_is_not_none() {
         assert_that(Some(1), is_not(none()));
     }
 }

--- a/src/matchers/vecs.rs
+++ b/src/matchers/vecs.rs
@@ -108,19 +108,19 @@ mod test {
     };
 
     #[test]
-    fn test_vec_contains() {
+    fn vec_contains() {
         assert_that(&vec!(1, 2, 3), contains(vec!(1, 2)));
         assert_that(&vec!(1, 2, 3), not(contains(vec!(4))));
     }
 
     #[test]
-    fn test_vec_contains_exactly() {
+    fn vec_contains_exactly() {
         assert_that(&vec!(1, 2, 3), contains(vec!(1, 2, 3)).exactly());
         assert_that(&vec!(1, 2, 3), not(contains(vec!(1, 2)).exactly()));
     }
 
     #[test]
-    fn test_vec_of_len() {
+    fn vec_of_len() {
         assert_that(&vec!(1, 2, 3), of_len(3));
         assert_that(&vec!(1, 2, 3), is(of_len(3)));
     }


### PR DESCRIPTION
Split up tests where it makes sense and find better names. The test modules are already called `test` so adding that to the function names is a bit redundant.