### PR TITLE
Add option to assert a Vec contains some elements in order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ authors = [
   "Urban Hafner <contact@urbanhafner.com>",
   "Valerii Hiora <valerii.hiora@gmail.com>",
   "Yehuda Katz <wycats@gmail.com>",
+  "Ian Létourneau <letourneau.ian@gmail.com>",
 ]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ assert_that!(None, is(none::<int>()));
 assert_that!(Some(1), is_not(none::<int>()));
 ```
 
-### contains and contains\_exactly
+### contains, contains\_exactly, contains\_in order
 
 ``` rust
 assert_that!(&vec!(1i, 2, 3), contains(vec!(1i, 2)));
@@ -67,6 +67,9 @@ assert_that!(&vec!(1i, 2, 3), not(contains(vec!(4i))));
 
 assert_that!(&vec!(1i, 2, 3), contains(vec!(1i, 2, 3)).exactly());
 assert_that!(&vec!(1i, 2, 3), not(contains(vec!(1i, 2)).exactly()));
+
+assert_that!(&vec!(1i, 2, 3), contains(vec!(1i, 2)).in_order());
+assert_that!(&vec!(1i, 2, 3), not(contains(vec!(1i, 3)).in_order()));
 ```
 
 ### matches_regex

--- a/tests/vecs.rs
+++ b/tests/vecs.rs
@@ -25,6 +25,28 @@ mod vecs {
     }
 
     #[test]
+    fn it_contains_elements_in_order() {
+        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2)).in_order());
+    }
+
+    #[test]
+    fn it_does_not_contain_elements_in_order() {
+        assert_that!(&vec!(1, 2, 3), not(contains(vec!(1, 3)).in_order()));
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_unsuccessfully_contains_elements_in_order() {
+        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 3)).in_order());
+    }
+
+    #[test]
+    #[should_panic]
+    fn it_unsuccessfully_does_not_contain_elements_in_order() {
+        assert_that!(&vec!(1, 2, 3), not(contains(vec!(2, 3)).in_order()));
+    }
+
+    #[test]
     fn vec_of_len() {
         assert_that!(&vec!(1, 2, 3), of_len(3));
         assert_that!(&vec!(1, 2, 3), is(of_len(3)));


### PR DESCRIPTION
Add option to matcher `Contains` to assert that a `Vec` contains some elements in same order.
```rust
assert_that!(&vec!(1i, 2, 3), contains(vec!(1i, 2)).in_order());
```