### PR TITLE
Configure travis to use rustfmt and fail if formatting is not correct + format project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,13 @@ rust:
 os:
   - linux
   - osx
+
+before_script:
+  - (cargo install rustfmt || true)
+
+script:
+  - |
+    export PATH=$PATH:~/.cargo/bin &&
+    cargo fmt -- --write-mode=diff &&
+    cargo build &&
+    cargo test

--- a/src/core.rs
+++ b/src/core.rs
@@ -17,12 +17,7 @@ pub fn success() -> MatchResult {
 }
 
 pub fn expect(predicate: bool, msg: String) -> MatchResult {
-    if predicate {
-        success()
-    }
-    else {
-        Err(msg)
-    }
+    if predicate { success() } else { Err(msg) }
 }
 
 #[deprecated(since = "0.1.2", note = "Use the assert_that! macro instead")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@ macro_rules! assert_that {
 pub mod core;
 pub mod matchers;
 pub mod prelude {
-    #[allow(deprecated)] pub use core::assert_that;
+    #[allow(deprecated)]
+    pub use core::assert_that;
     pub use core::Matcher as HamcrestMatcher;
     pub use matchers::close_to::close_to;
     pub use matchers::compared_to::less_than;

--- a/src/matchers/close_to.rs
+++ b/src/matchers/close_to.rs
@@ -58,6 +58,6 @@ impl<T: Float + Zero + Debug> Matcher<T> for CloseTo<T> {
 pub fn close_to<T>(expected: T, epsilon: T) -> CloseTo<T> {
     CloseTo {
         expected: expected,
-        epsilon: epsilon
+        epsilon: epsilon,
     }
 }

--- a/src/matchers/compared_to.rs
+++ b/src/matchers/compared_to.rs
@@ -39,7 +39,7 @@ impl<T: fmt::Debug> fmt::Display for ComparedTo<T> {
     }
 }
 
-impl<T : PartialOrd + fmt::Debug> Matcher<T> for ComparedTo<T> {
+impl<T: PartialOrd + fmt::Debug> Matcher<T> for ComparedTo<T> {
     fn matches(&self, actual: T) -> MatchResult {
         let it_succeeded = match self.operation {
             CompareOperation::LessOrEqual => actual <= self.right_hand_side,
@@ -50,37 +50,36 @@ impl<T : PartialOrd + fmt::Debug> Matcher<T> for ComparedTo<T> {
 
         if it_succeeded {
             success()
-        }
-        else {
+        } else {
             Err(format!("was {:?}", actual))
         }
     }
 }
 
-pub fn less_than<T : PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
+pub fn less_than<T: PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
     ComparedTo {
         operation: CompareOperation::LessThan,
-        right_hand_side: right_hand_side
+        right_hand_side: right_hand_side,
     }
 }
 
-pub fn less_than_or_equal_to<T : PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
+pub fn less_than_or_equal_to<T: PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
     ComparedTo {
         operation: CompareOperation::LessOrEqual,
-        right_hand_side: right_hand_side
+        right_hand_side: right_hand_side,
     }
 }
 
-pub fn greater_than<T : PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
+pub fn greater_than<T: PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
     ComparedTo {
         operation: CompareOperation::GreaterThan,
-        right_hand_side: right_hand_side
+        right_hand_side: right_hand_side,
     }
 }
 
-pub fn greater_than_or_equal_to<T : PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
+pub fn greater_than_or_equal_to<T: PartialOrd + fmt::Debug>(right_hand_side: T) -> ComparedTo<T> {
     ComparedTo {
         operation: CompareOperation::GreaterOrEqual,
-        right_hand_side: right_hand_side
+        right_hand_side: right_hand_side,
     }
 }

--- a/src/matchers/equal_to.rs
+++ b/src/matchers/equal_to.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use core::*;
 
 pub struct EqualTo<T> {
-    expected: T
+    expected: T,
 }
 
 impl<T: fmt::Debug> fmt::Display for EqualTo<T> {
@@ -23,17 +23,16 @@ impl<T: fmt::Debug> fmt::Display for EqualTo<T> {
     }
 }
 
-impl<T : PartialEq + fmt::Debug> Matcher<T> for EqualTo<T> {
+impl<T: PartialEq + fmt::Debug> Matcher<T> for EqualTo<T> {
     fn matches(&self, actual: T) -> MatchResult {
         if self.expected.eq(&actual) {
             success()
-        }
-        else {
+        } else {
             Err(format!("was {:?}", actual))
         }
     }
 }
 
-pub fn equal_to<T : PartialEq + fmt::Debug>(expected: T) -> EqualTo<T> {
+pub fn equal_to<T: PartialEq + fmt::Debug>(expected: T) -> EqualTo<T> {
     EqualTo { expected: expected }
 }

--- a/src/matchers/existing_path.rs
+++ b/src/matchers/existing_path.rs
@@ -19,12 +19,12 @@ use core::*;
 pub enum PathType {
     AnyType,
     File,
-    Dir
+    Dir,
 }
 
 #[derive(Clone, Copy)]
 pub struct ExistingPath {
-    path_type: PathType
+    path_type: PathType,
 }
 
 impl ExistingPath {
@@ -32,14 +32,12 @@ impl ExistingPath {
         let metadata = fs::metadata(actual);
         match self.path_type {
             PathType::File => {
-                expect(
-                    metadata.map(|m| m.is_file()).unwrap_or(false),
-                    format!("`{}` was not a file", actual.display()))
+                expect(metadata.map(|m| m.is_file()).unwrap_or(false),
+                       format!("`{}` was not a file", actual.display()))
             }
             PathType::Dir => {
-                expect(
-                    metadata.map(|m| m.is_dir()).unwrap_or(false),
-                    format!("`{}` was not a dir", actual.display()))
+                expect(metadata.map(|m| m.is_dir()).unwrap_or(false),
+                       format!("`{}` was not a dir", actual.display()))
             }
             _ => success(),
         }

--- a/src/matchers/is.rs
+++ b/src/matchers/is.rs
@@ -23,14 +23,17 @@ impl<T, M: Matcher<T>> fmt::Display for Is<T, M> {
     }
 }
 
-impl<T, M : Matcher<T>> Matcher<T> for Is<T, M> {
+impl<T, M: Matcher<T>> Matcher<T> for Is<T, M> {
     fn matches(&self, actual: T) -> MatchResult {
         self.matcher.matches(actual)
     }
 }
 
 pub fn is<T, M: Matcher<T>>(matcher: M) -> Is<T, M> {
-    Is { matcher: matcher, marker: PhantomData }
+    Is {
+        matcher: matcher,
+        marker: PhantomData,
+    }
 }
 
 pub struct IsNot<T, M> {
@@ -38,21 +41,24 @@ pub struct IsNot<T, M> {
     marker: PhantomData<T>,
 }
 
-impl<T, M : Matcher<T>> fmt::Display for IsNot<T, M> {
+impl<T, M: Matcher<T>> fmt::Display for IsNot<T, M> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "not {}", self.matcher)
     }
 }
 
-impl<T, M : Matcher<T>> Matcher<T> for IsNot<T, M> {
+impl<T, M: Matcher<T>> Matcher<T> for IsNot<T, M> {
     fn matches(&self, actual: T) -> MatchResult {
         match self.matcher.matches(actual) {
             Ok(_) => Err("matched".to_string()),
-            Err(_) => Ok(())
+            Err(_) => Ok(()),
         }
     }
 }
 
 pub fn is_not<T, M: Matcher<T>>(matcher: M) -> IsNot<T, M> {
-    IsNot { matcher: matcher, marker: PhantomData }
+    IsNot {
+        matcher: matcher,
+        marker: PhantomData,
+    }
 }

--- a/src/matchers/regex.rs
+++ b/src/matchers/regex.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use core::*;
 
 pub struct MatchesRegex {
-    regex: Regex
+    regex: Regex,
 }
 
 impl fmt::Display for MatchesRegex {
@@ -25,8 +25,7 @@ impl<'a> Matcher<&'a str> for MatchesRegex {
     fn matches(&self, actual: &'a str) -> MatchResult {
         if self.regex.is_match(actual) {
             success()
-        }
-        else {
+        } else {
             Err(format!("was {:?}", actual))
         }
     }

--- a/src/matchers/vecs.rs
+++ b/src/matchers/vecs.rs
@@ -17,7 +17,7 @@ use core::*;
 
 #[derive(Clone,Copy)]
 pub struct OfLen {
-    len: usize
+    len: usize,
 }
 
 impl fmt::Display for OfLen {
@@ -44,7 +44,7 @@ pub fn of_len(len: usize) -> OfLen {
 pub struct Contains<T> {
     items: Vec<T>,
     exactly: bool,
-    in_order: bool
+    in_order: bool,
 }
 
 impl<T> Contains<T> {
@@ -75,8 +75,10 @@ impl<'a, T: fmt::Debug + PartialEq + Clone> Matcher<&'a Vec<T>> for Contains<T> 
 
         for item in self.items.iter() {
             match rem.iter().position(|a| *item == *a) {
-                Some(idx) => { rem.remove(idx); },
-                None => return Err(format!("was {}", Pretty(&actual)))
+                Some(idx) => {
+                    rem.remove(idx);
+                }
+                None => return Err(format!("was {}", Pretty(&actual))),
             }
         }
 
@@ -85,7 +87,9 @@ impl<'a, T: fmt::Debug + PartialEq + Clone> Matcher<&'a Vec<T>> for Contains<T> 
         }
 
         if self.in_order && !contains_in_order(actual, &self.items) {
-            return Err(format!("{} does not contain {} in order", Pretty(&actual), Pretty(&self.items)));
+            return Err(format!("{} does not contain {} in order",
+                               Pretty(&actual),
+                               Pretty(&self.items)));
         }
 
         success()
@@ -102,8 +106,8 @@ fn contains_in_order<T: fmt::Debug + PartialEq>(actual: &Vec<T>, items: &Vec<T>)
                     return false;
                 }
                 previous = Some(current);
-            },
-            None => return false
+            }
+            None => return false,
         }
     }
 
@@ -118,7 +122,11 @@ fn is_next_index(current_index: &usize, previous_index: &Option<usize>) -> bool 
 }
 
 pub fn contains<T>(items: Vec<T>) -> Contains<T> {
-    Contains { items: items, exactly: false, in_order: false }
+    Contains {
+        items: items,
+        exactly: false,
+        in_order: false,
+    }
 }
 
 struct Pretty<'a, T: 'a>(&'a [T]);
@@ -127,7 +135,9 @@ impl<'a, T: fmt::Debug> fmt::Display for Pretty<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         try!(write!(f, "["));
         for (i, t) in self.0.iter().enumerate() {
-            if i != 0 { try!(write!(f, ", ")); }
+            if i != 0 {
+                try!(write!(f, ", "));
+            }
             try!(write!(f, "{:?}", t));
         }
         write!(f, "]")

--- a/tests/close_to.rs
+++ b/tests/close_to.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod close_to {
 

--- a/tests/compared_to.rs
+++ b/tests/compared_to.rs
@@ -7,7 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod compared_to {
 

--- a/tests/equal_to.rs
+++ b/tests/equal_to.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod equal_to {
 

--- a/tests/existing_path.rs
+++ b/tests/existing_path.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod existing_path {
 

--- a/tests/none.rs
+++ b/tests/none.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod none {
 

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod regex {
 

--- a/tests/vecs.rs
+++ b/tests/vecs.rs
@@ -6,7 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#[macro_use] extern crate hamcrest;
+#[macro_use]
+extern crate hamcrest;
 
 mod vecs {
 
@@ -14,42 +15,42 @@ mod vecs {
 
     #[test]
     fn vec_contains() {
-        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2)));
-        assert_that!(&vec!(1, 2, 3), not(contains(vec!(4))));
+        assert_that!(&vec![1, 2, 3], contains(vec![1, 2]));
+        assert_that!(&vec![1, 2, 3], not(contains(vec![4])));
     }
 
     #[test]
     fn vec_contains_exactly() {
-        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2, 3)).exactly());
-        assert_that!(&vec!(1, 2, 3), not(contains(vec!(1, 2)).exactly()));
+        assert_that!(&vec![1, 2, 3], contains(vec![1, 2, 3]).exactly());
+        assert_that!(&vec![1, 2, 3], not(contains(vec![1, 2]).exactly()));
     }
 
     #[test]
     fn it_contains_elements_in_order() {
-        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2)).in_order());
+        assert_that!(&vec![1, 2, 3], contains(vec![1, 2]).in_order());
     }
 
     #[test]
     fn it_does_not_contain_elements_in_order() {
-        assert_that!(&vec!(1, 2, 3), not(contains(vec!(1, 3)).in_order()));
+        assert_that!(&vec![1, 2, 3], not(contains(vec![1, 3]).in_order()));
     }
 
     #[test]
     #[should_panic]
     fn it_unsuccessfully_contains_elements_in_order() {
-        assert_that!(&vec!(1, 2, 3), contains(vec!(1, 3)).in_order());
+        assert_that!(&vec![1, 2, 3], contains(vec![1, 3]).in_order());
     }
 
     #[test]
     #[should_panic]
     fn it_unsuccessfully_does_not_contain_elements_in_order() {
-        assert_that!(&vec!(1, 2, 3), not(contains(vec!(2, 3)).in_order()));
+        assert_that!(&vec![1, 2, 3], not(contains(vec![2, 3]).in_order()));
     }
 
     #[test]
     fn vec_of_len() {
-        assert_that!(&vec!(1, 2, 3), of_len(3));
-        assert_that!(&vec!(1, 2, 3), is(of_len(3)));
+        assert_that!(&vec![1, 2, 3], of_len(3));
+        assert_that!(&vec![1, 2, 3], is(of_len(3)));
     }
 
 }


### PR DESCRIPTION
I did not change the default configuration for `rustfmt`, but feel free to tell me if there are some of the behaviors you want to override. Personally I prefer changing the `max_width` setting to something bigger than `100`, for instance `120` or `140`.

Fixes #39 