### PR TITLE
Rename contains matcher

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod prelude {
     pub use matchers::regex::matches_regex as match_regex;
     pub use matchers::regex::matches_regex;
     pub use matchers::vecs::contains;
+    pub use matchers::vecs::contains_all_of;
+    pub use matchers::vecs::contains_all_of as contain_all_of;
     pub use matchers::vecs::of_len;
     pub use matchers::anything::anything;
     pub use matchers::type_of::type_of;

--- a/src/matchers/vecs.rs
+++ b/src/matchers/vecs.rs
@@ -123,6 +123,19 @@ fn is_next_index(current_index: &usize, previous_index: &Option<usize>) -> bool 
     return true;
 }
 
+/// Creates a matcher that checks if actual vector has all items of the given vector.
+///
+/// # Examples
+///
+/// ```
+/// #[macro_use] extern crate hamcrest;
+/// use hamcrest::prelude::*;
+///
+/// fn main() {
+///     assert_that!(&vec![1, 2, 3, 4], contains_all_of(vec![1, 2, 3]));
+///     assert_that!(&vec![1, 2, 3], does_not(contain_all_of(vec![1, 2, 4])));
+/// }
+/// ```
 pub fn contains_all_of<T>(items: Vec<T>) -> Contains<T> {
     Contains {
         items: items,

--- a/src/matchers/vecs.rs
+++ b/src/matchers/vecs.rs
@@ -123,12 +123,17 @@ fn is_next_index(current_index: &usize, previous_index: &Option<usize>) -> bool 
     return true;
 }
 
-pub fn contains<T>(items: Vec<T>) -> Contains<T> {
+pub fn contains_all_of<T>(items: Vec<T>) -> Contains<T> {
     Contains {
         items: items,
         exactly: false,
         in_order: false,
     }
+}
+
+#[deprecated(since = "0.2.0", note = "Use the contains_all_of instead")]
+pub fn contains<T>(items: Vec<T>) -> Contains<T> {
+    contains_all_of(items)
 }
 
 struct Pretty<'a, T: 'a>(&'a [T]);

--- a/tests/all_of.rs
+++ b/tests/all_of.rs
@@ -19,10 +19,10 @@ mod all_of {
     }
 
     #[test]
-    fn vec_contains() {
+    fn vec_contains_all_of() {
         assert_that!(
             &vec![1, 2, 3],
-            all_of!(contains(vec![1, 2]), not(contains(vec![4])))
+            all_of!(contains_all_of(vec![1, 2]), not(contains_all_of(vec![4])))
         );
     }
 }

--- a/tests/any_of.rs
+++ b/tests/any_of.rs
@@ -19,10 +19,13 @@ mod any_of {
     }
 
     #[test]
-    fn vec_contains() {
+    fn vec_contains_all_of() {
         assert_that!(
             &vec![1, 2, 3],
-            any_of!(contains(vec![1, 2, 5]), not(contains(vec![4])))
+            any_of!(
+                contains_all_of(vec![1, 2, 5]),
+                not(contains_all_of(vec![4]))
+            )
         );
     }
 }

--- a/tests/vecs.rs
+++ b/tests/vecs.rs
@@ -14,37 +14,38 @@ mod vecs {
     use hamcrest::prelude::*;
 
     #[test]
-    fn vec_contains() {
-        assert_that!(&vec![1, 2, 3], contains(vec![1, 2]));
-        assert_that!(&vec![1, 2, 3], not(contains(vec![4])));
+    fn vec_contains_all_of() {
+        assert_that!(&vec![1, 2, 3], contains_all_of(vec![1, 2]));
+        assert_that!(&vec![1, 2, 3], not(contains_all_of(vec![4])));
+        assert_that!(&vec![1, 2, 3], does_not(contain_all_of(vec![4])));
     }
 
     #[test]
-    fn vec_contains_exactly() {
-        assert_that!(&vec![1, 2, 3], contains(vec![1, 2, 3]).exactly());
-        assert_that!(&vec![1, 2, 3], not(contains(vec![1, 2]).exactly()));
+    fn vec_contains_all_of_exactly() {
+        assert_that!(&vec![1, 2, 3], contains_all_of(vec![1, 2, 3]).exactly());
+        assert_that!(&vec![1, 2, 3], not(contains_all_of(vec![1, 2]).exactly()));
     }
 
     #[test]
-    fn it_contains_elements_in_order() {
-        assert_that!(&vec![1, 2, 3], contains(vec![1, 2]).in_order());
+    fn it_contains_all_of_elements_in_order() {
+        assert_that!(&vec![1, 2, 3], contains_all_of(vec![1, 2]).in_order());
     }
 
     #[test]
     fn it_does_not_contain_elements_in_order() {
-        assert_that!(&vec![1, 2, 3], not(contains(vec![1, 3]).in_order()));
+        assert_that!(&vec![1, 2, 3], not(contains_all_of(vec![1, 3]).in_order()));
     }
 
     #[test]
     #[should_panic]
-    fn it_unsuccessfully_contains_elements_in_order() {
-        assert_that!(&vec![1, 2, 3], contains(vec![1, 3]).in_order());
+    fn it_unsuccessfully_contains_all_of_elements_in_order() {
+        assert_that!(&vec![1, 2, 3], contains_all_of(vec![1, 3]).in_order());
     }
 
     #[test]
     #[should_panic]
     fn it_unsuccessfully_does_not_contain_elements_in_order() {
-        assert_that!(&vec![1, 2, 3], not(contains(vec![2, 3]).in_order()));
+        assert_that!(&vec![1, 2, 3], not(contains_all_of(vec![2, 3]).in_order()));
     }
 
     #[test]


### PR DESCRIPTION
Addresses https://github.com/ujh/hamcrest-rust/issues/45
As discussed this PR

* adds `contains_all_of`
* deprecates `contains`
* adds an alias `contain_all_of` so that `does_not(contain_all_of())` reads nice

Then, I guess, in the next future PR I'll make changes to `contains/contain` matchers to test only if a single element is in the list.