### PR TITLE
WIP: Potential API change

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -10,26 +10,99 @@
 
 use std::fmt;
 
-pub type MatchResult = Result<(), String>;
-
-pub fn success() -> MatchResult {
-    Ok(())
-}
-
-pub fn expect(predicate: bool, msg: String) -> MatchResult {
-    if predicate { success() } else { Err(msg) }
-}
-
-#[deprecated(since = "0.1.2", note = "Use the assert_that! macro instead")]
-pub fn assert_that<T, U: Matcher<T>>(actual: T, matcher: U) {
-    match matcher.matches(actual) {
-        Ok(_) => return,
-        Err(mismatch) => {
-            panic!("\nExpected: {}\n    but: {}", matcher, mismatch);
-        }
-    }
-}
-
+/// Principal trait to implement to extend Hamcrest.
 pub trait Matcher<T>: fmt::Display {
     fn matches(&self, actual: T) -> MatchResult;
 }
+
+/// Complete set of information that `Matcher`s must provide.
+pub struct MatchResult {
+    /// Matchers must provide a formatted version of any object they can attempt
+    /// to match. This is stored as `formatted_actual`.
+    formatted_actual: String,
+    /// Appearance of the `Matcher`, typically provided with `fmt::Display`.
+    formatted_matcher: String,
+    /// Matchers must also state whether the match was successful or not, and
+    /// optionally give an explanation for failures.
+    status: MatchStatus,
+}
+
+impl MatchResult {
+    /// Make a `MatchResult` indicating a successful match.
+    pub fn success(
+        formatted_matcher: String,
+        formatted_actual: String,
+    ) -> Self {
+        Self {
+            formatted_actual: formatted_actual,
+            formatted_matcher: formatted_matcher,
+            status: Ok(()),
+        }
+    }
+    /// Make a `MatchResult` indicating a failed match.
+    pub fn failure(
+        formatted_matcher: String,
+        formatted_actual: String,
+    ) -> Self {
+        Self {
+            formatted_actual: formatted_actual,
+            formatted_matcher: formatted_matcher,
+            status: Err(None),
+        }
+    }
+
+    /// Attach an explanation for why the match was unsuccessful.
+    pub fn with_explanation<TS: ToString>(self, explanation: TS) -> Self {
+        if self.status == Ok(()) {
+            panic!("Applied explanation to successful status")
+        }
+        Self {
+            status: Err(Some(explanation.to_string())),
+            ..self
+        }
+    }
+
+    pub fn formatted_assertion_failure(&self) -> String {
+        format!(
+            "\n  Expected: {}\n       Got: {}{}\n",
+            self.formatted_matcher(),
+            self.formatted_actual(),
+            match self.status {
+                Ok(()) => {
+                    panic!("Status was Ok");
+                }
+                Err(ref explanation_option) => match explanation_option {
+                    &Some(ref explanation) => format!(" ({})", explanation),
+                    &None => "".to_owned(),
+                },
+            }
+        )
+    }
+
+    pub fn formatted_actual(&self) -> &String {
+        return &self.formatted_actual;
+    }
+    pub fn formatted_matcher(&self) -> &String {
+        return &self.formatted_matcher;
+    }
+    pub fn status(&self) -> &MatchStatus {
+        return &self.status;
+    }
+}
+
+/// Preferred way of constructing a `MatchResult` indicating success.
+pub fn success<M: fmt::Display, TS: ToString>(
+    matcher: &M,
+    formatted_actual: TS,
+) -> MatchResult {
+    MatchResult::success(format!("{}", matcher), formatted_actual.to_string())
+}
+/// Preferred way of constructing a `MatchResult` indicating failure.
+pub fn failure<M: fmt::Display, TS: ToString>(
+    matcher: &M,
+    formatted_actual: TS,
+) -> MatchResult {
+    MatchResult::failure(format!("{}", matcher), formatted_actual.to_string())
+}
+
+pub type MatchStatus = Result<(), Option<String>>;


### PR DESCRIPTION
Hi!

I was trying to play around with this awesome library, and in so doing came up with some (potentially not completely backwards-compatible...) API changes that I think might be worthwhile. Thought I'd throw them together into a PR to get some feedback (prior to updating all the extant `Matcher` impls to adhere to the new API).

The main thing is to ask `Matcher`s to return the following complete set of information in a structured way:

1. What the `Matcher` looks like.
2. What the `Matcher` thinks the "actual" value should look like.
3. Whether the match was successful or not.
    1. And optionally an explanation for why the match was unsuccessful.

I also put in a slightly modified template for match-failure `panic` messages:

```rust
  Expected: <formatted matcher>
       Got: <formatted actual value>
```

Or, if an optional explanation is attached:

```rust
  Expected: <formatted matcher>
       Got: <formatted actual value> (<explanation>)
```

DO NOT MERGE. At the moment this is just a vessel for feedback.